### PR TITLE
SCVI+MMD: Variable-Strength Batch Correction with scVI

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -56,3 +56,7 @@ References
 .. [Lopez18] Romain Lopez, Jeffrey Regier, Michael Cole, Michael I. Jordan, Nir Yosef (2018),
    *Deep generative modeling for single-cell transcriptomics*,
    `Nature Methods <https://www.nature.com/articles/s41592-018-0229-2.epdf?author_access_token=5sMbnZl1iBFitATlpKkddtRgN0jAjWel9jnR3ZoTv0P1-tTjoP-mBfrGiMqpQx63aBtxToJssRfpqQ482otMbBw2GIGGeinWV4cULBLPg4L4DpCg92dEtoMaB1crCRDG7DgtNrM_1j17VfvHfoy1cQ%3D%3D>`__.
+
+.. [Gretton12] Arthur Gretton, Karsten M. Borgwardt, Malte J. Rasch, Bernhard Schölkopf, and Alexander Smola (2012),
+   *A Kernel Two-Sample Test*,
+   `Journal of Machine Learning Research <https://www.jmlr.org/papers/volume13/gretton12a/gretton12a.pdf>`__.

--- a/poetry.lock
+++ b/poetry.lock
@@ -809,7 +809,7 @@ python-igraph = ">=0.9.0"
 
 [[package]]
 name = "llvmlite"
-version = "0.35.0rc3"
+version = "0.34.0"
 description = "lightweight wrapper around basic LLVM functionality"
 category = "main"
 optional = false
@@ -2869,21 +2869,22 @@ leidenalg = [
     {file = "leidenalg-0.8.4.tar.gz", hash = "sha256:45764e0fc8829d23dee7698bd91d07c2027423d6309bd66b9711cdfecbcf8459"},
 ]
 llvmlite = [
-    {file = "llvmlite-0.35.0rc3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7b3b8b059f0449907c0376c7cecf6e0b4bdacc13797ab9f3cc64bb602e31c0a8"},
-    {file = "llvmlite-0.35.0rc3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:2d61fe18cf7b27f06e7663bd94d330d909e12a7595f220c7bff0f43ea271460c"},
-    {file = "llvmlite-0.35.0rc3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ecd9ba96592fb5f3a9b1645cc7c73b8a1f2e74573f2afe1af15f8d13556e6a4b"},
-    {file = "llvmlite-0.35.0rc3-cp36-cp36m-win32.whl", hash = "sha256:d80e892bf1278f6bc92e892e92f4b9170e02a1dfd9bbd618e23e76c47a1be3f7"},
-    {file = "llvmlite-0.35.0rc3-cp36-cp36m-win_amd64.whl", hash = "sha256:ea727570ce8ca621959df9fb39bb8cff103d9817bd5c9ed5980607fa3b67d0c4"},
-    {file = "llvmlite-0.35.0rc3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef23850e8720b52f3d5d5dd86566a9351f1d81d0c06cdb92f21c364aab53f4a8"},
-    {file = "llvmlite-0.35.0rc3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b1faf7c3ca9d3a5c95cc47682a3efab1a9f64e2862a5570d922e6ec216e21c74"},
-    {file = "llvmlite-0.35.0rc3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6d27b8c12c03dacd84e04db6c4bcf848d4aa7cbba51ee0625e46f7ced89ac603"},
-    {file = "llvmlite-0.35.0rc3-cp37-cp37m-win32.whl", hash = "sha256:c8748823e3901833c8aaec89a46d38e302a43a2ffa944c2edcbd60ef7bf521ee"},
-    {file = "llvmlite-0.35.0rc3-cp37-cp37m-win_amd64.whl", hash = "sha256:4cae79abf76b9ed801a0a27863c94c844712605868ff6802a2f402051ddf15c4"},
-    {file = "llvmlite-0.35.0rc3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:77a645b4ea84267fd497e45db531237dea097e2a0c3f0fa8ce66fbe6cd022924"},
-    {file = "llvmlite-0.35.0rc3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:fd0d534ded3a757611a2334bc9b1f5d2415bb34fc177793805ed4eac91cce0a5"},
-    {file = "llvmlite-0.35.0rc3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b3ac274cb3bd3caecf8fdfd15c99f293b187a8ea8be2c7706fb6a32d9fa4e284"},
-    {file = "llvmlite-0.35.0rc3-cp38-cp38-win32.whl", hash = "sha256:ee4cb5fe63b547cdfd77184e1d8d3992ede14ede47c178434b60851603c05896"},
-    {file = "llvmlite-0.35.0rc3-cp38-cp38-win_amd64.whl", hash = "sha256:c7c070bf9e194d3d731bdd7b75c28e39efcdac5ea888efc092922afdec33e938"},
+    {file = "llvmlite-0.34.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:11342e5ac320c953590bdd9d0dec8c52f4b5252c4c6335ba25f1e7b9f91f9325"},
+    {file = "llvmlite-0.34.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:5bdf0ce430adfaf938ced5844d12f80616eb8321b5b9edfc45ef84ada5c5242c"},
+    {file = "llvmlite-0.34.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e08d9d2dc5a31636bfc6b516d2d7daba95632afa3419eb8730dc76a7951e9558"},
+    {file = "llvmlite-0.34.0-cp36-cp36m-win32.whl", hash = "sha256:9ff1dcdad03be0cf953aca5fc8cffdca25ccee2ec9e8ec7e95571722cdc02d55"},
+    {file = "llvmlite-0.34.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5acdc3c3c7ea0ef7a1a6b442272e05d695bc8492e5b07666135ed1cfbf4ab9d2"},
+    {file = "llvmlite-0.34.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bb96989bc57a1ccb131e7a0e061d07b68139b6f81a98912345d53d9239e231e1"},
+    {file = "llvmlite-0.34.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6d3f81992f52a94077e7b9b16497029daf5b5eebb2cce56f3c8345bbc9c6308e"},
+    {file = "llvmlite-0.34.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d841248d1c630426c93e3eb3f8c45bca0dab77c09faeb7553b1a500220e362ce"},
+    {file = "llvmlite-0.34.0-cp37-cp37m-win32.whl", hash = "sha256:408b15ffec30696406e821c89da010f1bb1eb0aa572be4561c98eb2536d610ab"},
+    {file = "llvmlite-0.34.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5d1f370bf150db7239204f09cf6a0603292ea28bac984e69b167e16fe160d803"},
+    {file = "llvmlite-0.34.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:132322bc084abf336c80dd106f9357978c8c085911fb656898d3be0d9ff057ea"},
+    {file = "llvmlite-0.34.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:8f344102745fceba6eb5bf03c228bb290e9bc79157e9506a4a72878d636f9b3c"},
+    {file = "llvmlite-0.34.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:05253f3f44fab0148276335b2c1b2c4a78143dfa78e6bafd7f937d6248f297cc"},
+    {file = "llvmlite-0.34.0-cp38-cp38-win32.whl", hash = "sha256:28264f9e2b3df4135cbcfca5a91c5b0b31dd3fc02fa623b4bb13327f0cd4fc80"},
+    {file = "llvmlite-0.34.0-cp38-cp38-win_amd64.whl", hash = "sha256:964f8f7a2184963cb3617d057c2382575953e488b7bb061b632ee014cfef110a"},
+    {file = "llvmlite-0.34.0.tar.gz", hash = "sha256:f03ee0d19bca8f2fe922bb424a909d05c28411983b0c2bc58b020032a0d11f63"},
 ]
 loompy = [
     {file = "loompy-3.0.6.tar.gz", hash = "sha256:58e9763b8ab1af2a4a0e3805d120458b5184fd2b0f3031657ecce33c63ca4c46"},

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -47,6 +47,13 @@ class SCVI(
 
         * ``'normal'`` - Normal distribution
         * ``'ln'`` - Logistic normal distribution (Normal(0, I) transformed by softmax)
+    mmd_mode
+        Describes how to compute the MMD component of the objective (loss) function.
+        One of:
+        * ``'normal'`` - Compute the exact MMD loss
+        * ``'fast'`` - Compute the approximate MMD loss
+    mmd_loss_weight
+        Describes the weight of the MMD component in the overall loss function.
     **model_kwargs
         Keyword args for :class:`~scvi.module.VAE`
 
@@ -79,6 +86,8 @@ class SCVI(
         dispersion: Literal["gene", "gene-batch", "gene-label", "gene-cell"] = "gene",
         gene_likelihood: Literal["zinb", "nb", "poisson"] = "zinb",
         latent_distribution: Literal["normal", "ln"] = "normal",
+        mmd_mode: Literal["normal", "fast"] = "normal",
+        mmd_loss_weight: float = 1.0,
         **model_kwargs,
     ):
         super(SCVI, self).__init__(adata)
@@ -101,11 +110,13 @@ class SCVI(
             dispersion=dispersion,
             gene_likelihood=gene_likelihood,
             latent_distribution=latent_distribution,
+            mmd_mode=mmd_mode,
+            mmd_loss_weight=mmd_loss_weight,
             **model_kwargs,
         )
         self._model_summary_string = (
             "SCVI Model with the following params: \nn_hidden: {}, n_latent: {}, n_layers: {}, dropout_rate: "
-            "{}, dispersion: {}, gene_likelihood: {}, latent_distribution: {}"
+            "{}, dispersion: {}, gene_likelihood: {}, latent_distribution: {}, mmd_mode: {}, mmd_loss_weight: {}"
         ).format(
             n_hidden,
             n_latent,
@@ -114,5 +125,7 @@ class SCVI(
             dispersion,
             gene_likelihood,
             latent_distribution,
+            mmd_mode,
+            mmd_loss_weight,
         )
         self.init_params_ = self._get_init_params(locals())

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Main module."""
-import warnings
 from typing import Callable, Iterable, Optional
 
 import numpy as np
@@ -380,12 +379,6 @@ class VAE(BaseModuleClass):
 
         # z1_size and z2_size must match, otherwise pick their min
         batch_size = min(z1_size, z2_size)
-        if z1_size != z2_size:
-            warnings.warn(
-                "z1 and z2 don't have matching batch sizes, picking their min: {}.".format(
-                    batch_size
-                )
-            )
 
         # Drop a sample if batch_size is not even
         if batch_size % 2 != 0:

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -507,7 +507,7 @@ class VAE(BaseModuleClass):
             kl_divergence_l=kl_divergence_l, kl_divergence_z=kl_divergence_z
         )
         kl_global = 0.0
-        return LossRecorder(loss, reconst_loss, kl_local, kl_global)
+        return LossRecorder(loss, reconst_loss, kl_local, kl_global, mmd=mmd_loss)
 
     @torch.no_grad()
     def sample(

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -436,7 +436,7 @@ class VAE(BaseModuleClass):
         -------
         Tensor with one item containing the MMD loss for the samples in ``z``
         """
-        mmd_loss = 0.0
+        mmd_loss = torch.tensor(0.0, device=z.device)
         batches = torch.unique(batch_indices)
         for b0, b1 in zip(batches, batches[1:]):
             z0 = z[(batch_indices == b0).reshape(-1)]

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -338,8 +338,7 @@ class VAE(BaseModuleClass):
 
     def _compute_mmd(self, z1: torch.Tensor, z2: torch.Tensor) -> torch.Tensor:
         """
-        Computes the Maximum Mean Discrepancy (MMD) of ``z1`` and ``z2``.
-        TODO cite paper
+        Computes the Maximum Mean Discrepancy (MMD) of ``z1`` and ``z2`` as described in [Gretton12]_.
         Based on https://github.com/napsternxg/pytorch-practice/blob/master/Pytorch%20-%20MMD%20VAE.ipynb
 
         Parameters

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -436,7 +436,7 @@ class VAE(BaseModuleClass):
         -------
         Tensor with one item containing the MMD loss for the samples in ``z``
         """
-        mmd_loss = torch.tensor(0.0)
+        mmd_loss = torch.tensor(0.0, device=z.device)
         batches = torch.unique(batch_indices)
         for b0, b1 in zip(batches, batches[1:]):
             z0 = z[(batch_indices == b0).reshape(-1)]

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -78,6 +78,13 @@ class VAE(BaseModuleClass):
     var_activation
         Callable used to ensure positivity of the variational distributions' variance.
         When `None`, defaults to `torch.exp`.
+    mmd_mode
+        Describes how to compute the MMD component of the objective (loss) function.
+        One of:
+        * ``'normal'`` - Compute the exact MMD loss
+        * ``'fast'`` - Compute the approximate MMD loss
+    mmd_loss_weight
+        Describes the weight of the MMD component in the overall loss function.
     """
 
     def __init__(
@@ -436,7 +443,7 @@ class VAE(BaseModuleClass):
         -------
         Tensor with one item containing the MMD loss for the samples in ``z``
         """
-        mmd_loss = torch.tensor(0.0, device=z.device)
+        mmd_loss = 0.0
         batches = torch.unique(batch_indices)
         for b0, b1 in zip(batches, batches[1:]):
             z0 = z[(batch_indices == b0).reshape(-1)]

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -198,6 +198,8 @@ def test_scvi(save_path):
     assert "mmd_loss_validation" in model.history.keys()
     assert len(model.history["mmd_loss_train"]) == 1
     assert len(model.history["mmd_loss_validation"]) == 1
+    assert not np.isnan(model.history["mmd_loss_train"].values[0][0])
+    assert not np.isnan(model.history["mmd_loss_validation"].values[0][0])
     model.get_mmd_loss()
 
 
@@ -274,7 +276,7 @@ def test_scvi_mmd(save_path):
     model.train(max_epochs=1)
     assert "mmd_loss_train" in model.history.keys()
     assert len(model.history["mmd_loss_train"]) == 1
-    assert model.history["mmd_loss_train"].to_numpy()[0][0] == 0.0
+    assert model.history["mmd_loss_train"].values[0][0] == 0.0
 
     # validate ValueError is raised if mmd mode is unrecognized
     adata = synthetic_iid(n_batches=2)


### PR DESCRIPTION
This change adds a component onto the VAE objective function which measures the extent to which posterior distributions for different batches are dissimilar. Essentially, this measures the effectiveness of the batch effect correction. This component is added onto the loss with a scaling factor - beta - which can be used to regulate the batch effect correction (note that at its extreme, batch effect correction can cause a potential over-mixing of cells due to enforcing over-similarity of latent distributions).

The newly added component consists of the aggregate Maximum Mean Discrepancy (https://www.jmlr.org/papers/volume13/gretton12a/gretton12a.pdf), aka MMD, of pairs of sets of samples taken from the latent distributions, grouped per their originator batch. We provide two modes of computation, ‘normal’ and ‘fast’, where the former computes the exact MMD (quadratic runtime in the number of samples) while the latter computes a fast approximation of the MMD (linear runtime in the number of samples). Furthermore, in the spirit of fast approximations, we only compute the MMD for sequential pairs of batches rather than for all pair-wise combinations.

MMD parameters (mode and weight) can be set during model instantiation. The MMD loss is recorded in the history of the trainer and thus is available from the model history once training is complete.

### Details of the MMD computation
The formula used for the normal (exact) computation is formula 5 in the paper linked above. We use a Gaussian kernel with gamma=1. X and Y in our case are two sets of samples Z1 and Z2 taken from the latent space where Z1 corresponds to cells originating from batch k and Z2 corresponds to cells originating from batch k’. We carry this out for all sequential (k, k’) pairs and sum over all of them to obtain the aggregate MMD loss, L_mmd.

Finally, the existing SCVI loss (negative ELBO) is updated as follows:
L_scvi-mmd = L_scvi + beta*L_mmd

In fast mode, we proceed the same way as above, with the exception that the formula used for the MMD computation is the one presented in Lemma 14 in the paper linked above.

### Results
The following Colab notebooks show runs of the current and updated SCVI models along with training curves and training runtimes: [notebook1](https://colab.research.google.com/drive/1-anjiljiH3fFVjvTDEtN8GijWU4e1psL?usp=sharing) for the current model, [notebook2](https://colab.research.google.com/drive/1u0aaZkNzW5omFq1deR8vT1LEeSrw-wJj?usp=sharing) for the updated model.

### Changes to poetry.lock
This change-list also includes a minor change to the poetry.lock file that updates the version of the llvmlite package. Currently Poetry fails dependency resolution with a SolverProblemError because the declared numba and llvmlite versions do not match. In fact, the numba 0.51.2 release notes (https://pypi.org/project/numba/0.51.2/) declare that it is only compatible with llvmlite 0.34.*, which mismatches the version of llvmlite declared currently in the .lock file (0.35.0rc2). 